### PR TITLE
Bump UP Version to 1.0.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   update_version:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    # Check if the pull request was merged or a new tag was created
+    if: github.event.pull_request.merged == true || (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install repository
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install -e .
+          python3 -m pip install -e ".[engines]"
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     language_version:
       python: $(python3 --version | cut -d' ' -f2)
       pyproject_toml: ./pyproject.toml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.11.0
     hooks:
       - id: black
         args: [--config=pyproject.toml]
@@ -33,7 +33,7 @@ repos:
         args: [--settings-path=pyproject.toml]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.5.1" # Use the sha / tag you want to point at
+    rev: "v1.7.1" # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         files: "up_esb/.*\\.py$"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.9.1
     hooks:
       - id: black
         args: [--config=pyproject.toml]
@@ -33,7 +33,7 @@ repos:
         args: [--settings-path=pyproject.toml]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.3.0" # Use the sha / tag you want to point at
+    rev: "v1.5.1" # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         files: "up_esb/.*\\.py$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ Repository = "https://github.com/aiplan4eu/embedded-systems-bridge"
 [project.optional-dependencies]
 dev = ["black", "mypy", "pylint", "pytest", "pre-commit"]
 engines = [
-  "up-aries==0.1.0",
+  "up-aries",
   # "up-fast-downward>=0.3.1",
-  "up-pyperplan==1.0.0.1.dev1",
+  "up-pyperplan",
 ]
 
 ####################################################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,9 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-  "unified-planning[engines]==0.5.0.438.dev1",
+  "unified-planning==1.0.0",
   "networkx",
   "matplotlib",
-  "pydot",
 ]
 description = "General functionalities for using unified-planning in robotic applications"
 keywords = ["unified-planning", "embedded-systems-bridge"]
@@ -32,11 +31,16 @@ requires-python = ">=3.8"
 version = "0.0.177"
 
 [project.urls]
-Repository = "https://github.com/aiplan4eu/embedded-systems-bridge"
 Homepage = "https://www.aiplan4eu-project.eu/"
+Repository = "https://github.com/aiplan4eu/embedded-systems-bridge"
 
 [project.optional-dependencies]
-dev = ["black", "pylint", "pytest", "pre-commit"]
+dev = ["black", "mypy", "pylint", "pytest", "pre-commit"]
+engines = [
+  "up-aries==0.1.0",
+  # "up-fast-downward>=0.3.1",
+  "up-pyperplan==1.0.0.1.dev1",
+]
 
 ####################################################################################################
 #

--- a/tests/components/test_expression_manager.py
+++ b/tests/components/test_expression_manager.py
@@ -56,11 +56,6 @@ def fluent_arg_int_1_fun(arg: int):
     return arg
 
 
-def fluent_arg_real_1_fun(arg: float):
-    """Fluent real 1."""
-    return arg
-
-
 def fluent_arg_object(arg: TestObject) -> TestObject:
     """Fluent real 1."""
     return arg
@@ -74,12 +69,10 @@ class TestExpressionManager(unittest.TestCase):
         self._fluent_bool_1 = self.bridge.create_fluent_from_function(fluent_bool_1_fun)
         self._fluent_bool_2 = self.bridge.create_fluent_from_function(fluent_bool_2_fun)
         self._fluent_int_1 = self.bridge.create_fluent_from_function(fluent_int_1_fun)
-        # self._fluent_real_1 = self.bridge.create_fluent_from_function(fluent_real_1_fun)
+        self._fluent_real_1 = self.bridge.create_fluent_from_function(fluent_real_1_fun)
 
         self._fluent_arg_bool_1 = self.bridge.create_fluent_from_function(fluent_arg_bool_1_fun)
         self._fluent_arg_int_1 = self.bridge.create_fluent_from_function(fluent_arg_int_1_fun)
-        # TODO: fix this UP==1.0.0 fails creating with a fluent with a realtype argument
-        # self._fluent_arg_real_1 = self.bridge.create_fluent_from_function(fluent_arg_real_1_fun)
 
         self.bridge.create_types([TestObject])
         self._fluent_arg_object = self.bridge.create_fluent_from_function(fluent_arg_object)
@@ -105,7 +98,7 @@ class TestExpressionManager(unittest.TestCase):
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, False)
 
-        # result = self.ast.convert(Not(And(self._fluent_real_1, self._fluent_real_1)))
+        result = self.ast.convert(Not(And(self._fluent_real_1, self._fluent_real_1)))
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, False)
 
@@ -130,16 +123,8 @@ class TestExpressionManager(unittest.TestCase):
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, False)
 
-        # result = self.ast.convert(Not(self._fluent_arg_real_1(1)))
-        actual = eval(compile(result, filename="<ast>", mode="eval"))
-        self.assertEqual(actual, False)
-
     def test_simple_nested_fluents_with_args(self):
         result = self.ast.convert(Not(And(self._fluent_arg_int_1(1), self._fluent_arg_int_1(1))))
-        actual = eval(compile(result, filename="<ast>", mode="eval"))
-        self.assertEqual(actual, False)
-
-        # result = self.ast.convert(Not(And(self._fluent_arg_real_1(1), self._fluent_arg_real_1(1))))
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, False)
 

--- a/tests/components/test_expression_manager.py
+++ b/tests/components/test_expression_manager.py
@@ -74,11 +74,12 @@ class TestExpressionManager(unittest.TestCase):
         self._fluent_bool_1 = self.bridge.create_fluent_from_function(fluent_bool_1_fun)
         self._fluent_bool_2 = self.bridge.create_fluent_from_function(fluent_bool_2_fun)
         self._fluent_int_1 = self.bridge.create_fluent_from_function(fluent_int_1_fun)
-        self._fluent_real_1 = self.bridge.create_fluent_from_function(fluent_real_1_fun)
+        # self._fluent_real_1 = self.bridge.create_fluent_from_function(fluent_real_1_fun)
 
         self._fluent_arg_bool_1 = self.bridge.create_fluent_from_function(fluent_arg_bool_1_fun)
         self._fluent_arg_int_1 = self.bridge.create_fluent_from_function(fluent_arg_int_1_fun)
-        self._fluent_arg_real_1 = self.bridge.create_fluent_from_function(fluent_arg_real_1_fun)
+        # TODO: fix this UP==1.0.0 fails creating with a fluent with a realtype argument
+        # self._fluent_arg_real_1 = self.bridge.create_fluent_from_function(fluent_arg_real_1_fun)
 
         self.bridge.create_types([TestObject])
         self._fluent_arg_object = self.bridge.create_fluent_from_function(fluent_arg_object)
@@ -104,7 +105,7 @@ class TestExpressionManager(unittest.TestCase):
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, False)
 
-        result = self.ast.convert(Not(And(self._fluent_real_1, self._fluent_real_1)))
+        # result = self.ast.convert(Not(And(self._fluent_real_1, self._fluent_real_1)))
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, False)
 
@@ -129,7 +130,7 @@ class TestExpressionManager(unittest.TestCase):
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, False)
 
-        result = self.ast.convert(Not(self._fluent_arg_real_1(1)))
+        # result = self.ast.convert(Not(self._fluent_arg_real_1(1)))
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, False)
 
@@ -138,7 +139,7 @@ class TestExpressionManager(unittest.TestCase):
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, False)
 
-        result = self.ast.convert(Not(And(self._fluent_arg_real_1(1), self._fluent_arg_real_1(1))))
+        # result = self.ast.convert(Not(And(self._fluent_arg_real_1(1), self._fluent_arg_real_1(1))))
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, False)
 

--- a/up_esb/bridge.py
+++ b/up_esb/bridge.py
@@ -56,11 +56,6 @@ class Bridge:
 
     def __init__(self) -> None:
         # Note: Map from type instead of str to recognize subclasses.
-        self._types: Dict[type, Type] = {
-            bool: BoolType(),
-            int: IntType(lower_bound=0, upper_bound=100),
-            float: RealType(),
-        }
         self._fluents: Dict[str, Fluent] = {}
         self._fluent_functions: Dict[str, Callable[..., object]] = {}
         self._api_function_names: Set[str] = set()
@@ -68,6 +63,38 @@ class Bridge:
         self._api_actions: Dict[str, Callable[..., object]] = {}
         self._objects: Dict[str, Object] = {}
         self._api_objects: Dict[str, object] = {}
+
+        self._int_bounds: Tuple[int, int] = (0, 100)
+        self._real_bounds: Tuple[float, float] = (0, 100)
+        self._types: Dict[type, Type] = {
+            bool: BoolType(),
+            int: IntType(lower_bound=self._int_bounds[0], upper_bound=self._int_bounds[1]),
+            float: RealType(lower_bound=self._real_bounds[0], upper_bound=self._real_bounds[1]),
+        }
+
+    @property
+    def int_bounds(self) -> Tuple[int, int]:
+        """Return bounds for int type."""
+        return self._int_bounds
+
+    @int_bounds.setter
+    def int_bounds(self, bounds: Tuple[int, int]) -> None:
+        """Set bounds for int type."""
+        self._int_bounds = bounds
+        assert bounds[0] <= bounds[1], f"Invalid bounds {bounds}!"
+        self._types[int] = IntType(lower_bound=bounds[0], upper_bound=bounds[1])
+
+    @property
+    def real_bounds(self) -> Tuple[float, float]:
+        """Return bounds for real type."""
+        return self._real_bounds
+
+    @real_bounds.setter
+    def real_bounds(self, bounds: Tuple[float, float]) -> None:
+        """Set bounds for real type."""
+        self._real_bounds = bounds
+        assert bounds[0] <= bounds[1], f"Invalid bounds {bounds}!"
+        self._types[float] = RealType(lower_bound=bounds[0], upper_bound=bounds[1])
 
     @property
     def objects(self) -> Dict[str, Object]:

--- a/up_esb/bridge.py
+++ b/up_esb/bridge.py
@@ -58,7 +58,7 @@ class Bridge:
         # Note: Map from type instead of str to recognize subclasses.
         self._types: Dict[type, Type] = {
             bool: BoolType(),
-            int: IntType(),
+            int: IntType(lower_bound=0, upper_bound=100),
             float: RealType(),
         }
         self._fluents: Dict[str, Fluent] = {}

--- a/up_esb/components/graph.py
+++ b/up_esb/components/graph.py
@@ -152,7 +152,11 @@ def _time_triggered_plan_to_dependency_graph(plan: TimeTriggeredPlan) -> nx.DiGr
     )
     for i, (start, action, duration) in enumerate(plan.timed_actions):
         child_id = i + 1
-        duration = float(duration.numerator) / float(duration.denominator)
+        # TODO: Handle None Durations as Instantaneous Action Node
+        if duration:
+            duration = float(duration.numerator) / float(duration.denominator)
+        else:
+            duration = 0.0
         parameters, preconditions, postconditions = _process_action(action)
 
         dependency_graph.add_node(
@@ -179,7 +183,10 @@ def _time_triggered_plan_to_dependency_graph(plan: TimeTriggeredPlan) -> nx.DiGr
         dependency_graph.add_edge(parent_id, child_id)
         if i + 1 < len(plan.timed_actions):
             next_start, next_action, next_duration = plan.timed_actions[i + 1]
-            next_duration = float(next_duration.numerator) / float(next_duration.denominator)
+            if next_duration:
+                next_duration = float(next_duration.numerator) / float(next_duration.denominator)
+            else:
+                next_duration = 0.0
             if start != next_start:
                 parent_id = child_id
                 for next_parent in next_parents:


### PR DESCRIPTION
Closes #38 

I have bumped the UP dependency to 1.0 and adapted the related changes. 

 - One option that has been removed from the test cases during this transition is the creation of the fluents with `RealType` parameters
```py
# Using UP 1.0.0
from unified_planning.shortcuts import *
some_param = RealType(0,100)
f = Fluent("robot", RealType(0,100), param=some_param)
"""
Raises

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/python3.8/site-packages/unified_planning/model/fluent.py", line 82, in __init__
    raise UPTypeError(
unified_planning.exceptions.UPTypeError: Parameter real[0, 100] param of fluent robot has type real[0, 100]; fluents parameters must have finite domains.
"""
```
 - I have relaxed the versions for the up planners that were available previously. From now, engines can be installed using `pip install "up-esb[engines]"`
 - I have also bumped the version of `up-esb` to `0.1.0`