### PR TITLE
Relax unified planning version requirement to >= 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-  "unified-planning==1.0.0",
+  "unified-planning>=1.0.0",
   "networkx",
   "matplotlib",
 ]


### PR DESCRIPTION
For our [mobipick_labs](https://github.com/DFKI-NI/mobipick_labs) setup, we currently require `unified-planning==1.1.0`, the esb however requires `unified-planning==1.0.0`, relaxing the requirement to `>=1.0.0` would help to solve the pip dependency incompatibility.  Any thoughts against this`