### PR TITLE
Fix precommit config and fix workflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Build & Test
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,10 @@ repos:
           - --show-fixes
 
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 24.8.0
     hooks:
       - id: black
         args: [--config=pyproject.toml]
-        always_run: true
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.15.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,32 +5,26 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
+    hooks:
+      - id: ruff
+        files: ^up_esb/.*\.py$
+        args:
+          - --config=pyproject.toml
+          - --fix
+          - --show-fixes
+
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 25.1.0
     hooks:
       - id: black
         args: [--config=pyproject.toml]
-  - repo: https://github.com/pycqa/pylint
-    rev: v3.3.3
-    hooks:
-      - id: pylint
-        files: "up_esb/.*\\.py$"
-        args: [
-            --rcfile=pyproject.toml,
-            --fail-under=8.0,
-            --jobs=0,
-            --output-format=colorized,
-            --disable=import-error,
-          ]
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        files: "\\.(py)$"
-        args: [--settings-path=pyproject.toml]
+        always_run: true
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.9.0" # Use the sha / tag you want to point at
+    rev: "v1.15.0"
     hooks:
       - id: mypy
         files: "up_esb/.*\\.py$"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         args: [--config=pyproject.toml]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.15.0"
+    rev: "v1.14.1"
     hooks:
       - id: mypy
         files: "up_esb/.*\\.py$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ Homepage = "https://www.aiplan4eu-project.eu/"
 Repository = "https://github.com/aiplan4eu/embedded-systems-bridge"
 
 [project.optional-dependencies]
-dev = ["black", "mypy", "pylint", "pytest", "pre-commit"]
+dev = ["black", "mypy", "ruff", "pytest", "pre-commit"]
 engines = [
   "up-aries",
   # "up-fast-downward>=0.3.1",
@@ -47,14 +47,10 @@ engines = [
 # DEVELOPMENT
 #
 ####################################################################################################
-[tool.isort]
-ensure_newline_before_comments = true
-force_grid_wrap = 0
-include_trailing_comma = true
-line_length = 100
-multi_line_output = 3
-use_parentheses = true
 
+# ──────────────────────────────
+#  CODE FORMATTER – Black
+# ──────────────────────────────
 [tool.black]
 exclude = '''
 /(
@@ -67,10 +63,11 @@ exclude = '''
 )/
 '''
 line-length = 100
-target-version = ["py36", "py37", "py38"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 
-# ------------------------------------------------------------------------------
-# pytest configurations
+# ──────────────────────────────
+#  TEST RUNNER – Pytest
+# ──────────────────────────────
 [tool.pytest.ini_options]
 ignore = [".tox", ".direnv", "python_venv", "env", "venv"]
 
@@ -81,414 +78,16 @@ ignore = [".tox", ".direnv", "python_venv", "env", "venv"]
 # tests by accident.
 testpaths = ["up_esb.tests"]
 
-# ------------------------------------------------------------------------------
-# Pylint Configurations
-[tool.pylint.'MASTER']
-disable = [
-  "invalid-name",
-  "bare-except",
-  "broad-except",
-  "redefined-outer-name",
-  "too-many-arguments",
-  "too-many-instance-attributes",
-  "duplicate-code",
-  "fixme",
-  "too-few-public-methods",
+
+# ──────────────────────────────
+#  LINTER & IMPORT-SORTER – Ruff
+# ──────────────────────────────
+[tool.ruff]
+line-length = 100
+target-version = "py38"
+lint.extend-select = [
+  "I",    # isort-compatible import sorting
+  "B",    # bugbear – opinionated bug patterns
+  "SIM",  # flake8-simplify
+  "C4",   # flake8-comprehensions
 ]
-extension-pkg-whitelist = [] # "grpc"
-jobs = 0 # 0 for Auto-detect
-
-# List of plugins (as comma separated values of python module names) to load,
-# usually to register additional checkers.
-load-plugins = []
-
-[tool.pylint.'REPORTS']
-# Python expression which should return a score less than or equal to 10. You
-# have access to the variables 'error', 'warning', 'refactor', and 'convention'
-# which contain the number of messages in each category, as well as 'statement'
-# which is the total number of statements analyzed. This score is used by the
-# global evaluation report (RP0004).
-evaluation = "10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)"
-
-# Template used to display messages. This is a python new-style format string
-# used to format the message information. See doc for all details.
-#msg-template=
-
-# Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio). You can also give a reporter class, e.g.
-# mypackage.mymodule.MyReporterClass.
-output-format = "text"
-
-# Tells whether to display a full report or only the messages.
-reports = true
-
-# Activate the evaluation score.
-score = true
-
-[tool.pylint.'REFACTORING']
-# Maximum number of nested blocks for function / method body
-max-nested-blocks = 5
-
-# Complete name of functions that never returns. When checking for
-# inconsistent-return-statements if a never returning function is called then
-# it will be considered as an explicit return statement and no message will be
-# printed.
-never-returning-functions = ["sys.exit"]
-
-[tool.pylint.'TYPECHECK']
-# List of decorators that produce context managers, such as
-# contextlib.contextmanager. Add to this list to register other decorators that
-# produce valid context managers.
-contextmanager-decorators = ["contextlib.contextmanager"]
-
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E1101 when accessed. Python regular
-# expressions are accepted.
-generated-members = []
-
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members = true
-
-# Tells whether to warn about missing members when the owner of the attribute
-# is inferred to be None.
-ignore-none = true
-
-# This flag controls whether pylint should warn about no-member and similar
-# checks whenever an opaque object is returned when inferring. The inference
-# can return multiple potential results while evaluating a Python object, but
-# some branches might not be evaluated, which results in partial inference. In
-# that case, it might be useful to still emit no-member and other checks for
-# the rest of the inferred objects.
-ignore-on-opaque-inference = true
-
-# List of class names for which member attributes should not be checked (useful
-# for classes with dynamically set attributes). This supports the use of
-# qualified names.
-ignored-classes = ["optparse.Values", "thread._local", "_thread._local"]
-
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis). It
-# supports qualified module names, as well as Unix pattern matching.
-ignored-modules = []
-
-# Show a hint with possible names when a member name was not found. The aspect
-# of finding the hint is based on edit distance.
-missing-member-hint = true
-
-# The minimum edit distance a name should have in order to be considered a
-# similar match for a missing member name.
-missing-member-hint-distance = 1
-
-# The total number of similar names that should be taken in consideration when
-# showing a hint for a missing member.
-missing-member-max-choices = 1
-
-# List of decorators that change the signature of a decorated function.
-signature-mutators = []
-
-[tool.pylint.'VARIABLES']
-# List of additional names supposed to be defined in builtins. Remember that
-# you should avoid defining new builtins when possible.
-additional-builtins = []
-
-# Tells whether unused global variables should be treated as a violation.
-allow-global-unused-variables = true
-
-# List of strings which can identify a callback function by name. A callback
-# name must start or end with one of those strings.
-callbacks = ["cb_", "_cb"]
-
-# A regular expression matching the name of dummy variables (i.e. expected to
-# not be used).
-#dummy-variables-rgx="+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_"
-
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore.
-ignored-argument-names = "_.*|^ignored_|^unused_"
-
-# Tells whether we should check for unused import in __init__ files.
-init-import = false
-
-# List of qualified module names which can have objects that can redefine
-# builtins.
-redefining-builtins-modules = ["six.moves", "past.builtins", "future.builtins", "builtins", "io"]
-
-[tool.pylint.'LOGGING']
-# The type of string formatting that logging methods do. `old` means using %
-# formatting, `new` is for `{}` formatting.
-logging-format-style = "old"
-
-# Logging modules to check that the string format arguments are in logging
-# function parameter format.
-logging-modules = "logging"
-
-[tool.pylint.'MISCELLANEOUS']
-# List of note tags to take in consideration, separated by a comma.
-notes = ["FIXME", "XXX", "TODO"]
-
-# Regular expression of note tags to take in consideration.
-# notes-rgx=
-
-[tool.pylint.'SIMILARITIES']
-# Ignore comments when computing similarities.
-ignore-comments = true
-
-# Ignore docstrings when computing similarities.
-ignore-docstrings = true
-
-# Ignore imports when computing similarities.
-ignore-imports = false
-
-# Minimum lines number of a similarity.
-min-similarity-lines = 4
-
-[tool.pylint.'SPELLING']
-# Limits count of emitted suggestions for spelling mistakes.
-max-spelling-suggestions = 4
-
-# Spelling dictionary name. Available dictionaries: none. To make it work,
-# install the python-enchant package.
-spelling-dict = []
-
-# List of comma separated words that should not be checked.
-spelling-ignore-words = []
-
-# A path to a file that contains the private dictionary; one word per line.
-spelling-private-dict-file = []
-
-# Tells whether to store unknown words to the private dictionary (see the
-# --spelling-private-dict-file option) instead of raising a message.
-spelling-store-unknown-words = false
-
-[tool.pylint.'STRING']
-# This flag controls whether inconsistent-quotes generates a warning when the
-# character used as a quote delimiter is used inconsistently within a module.
-check-quote-consistency = false
-
-# This flag controls whether the implicit-str-concat should generate a warning
-# on implicit string concatenation in sequences defined over several lines.
-check-str-concat-over-line-jumps = false
-
-[tool.pylint.'FORMAT']
-# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-expected-line-ending-format = []
-
-# Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines = '^\s*(# )?<?https?://\S+>?$'
-
-# Number of spaces of indent required inside a hanging or continued line.
-indent-after-paren = 4
-
-# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
-# tab).
-indent-string = '    '
-
-# Maximum number of characters on a single line.
-max-line-length = 100
-
-# Maximum number of lines in a module.
-max-module-lines = 1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check = ["trailing-comma", "dict-separator"]
-
-# Allow the body of a class to be on the same line as the declaration if body
-# contains single statement.
-single-line-class-stmt = false
-
-# Allow the body of an if to be on the same line as the test if there is no
-# else.
-single-line-if-stmt = false
-
-[tool.pylint.'BASIC']
-# Naming style matching correct argument names.
-argument-naming-style = "snake_case"
-
-# Regular expression matching correct argument names. Overrides argument-
-# naming-style.
-#argument-rgx=
-
-# Naming style matching correct attribute names.
-attr-naming-style = "snake_case"
-
-# Regular expression matching correct attribute names. Overrides attr-naming-
-# style.
-#attr-rgx=
-
-# Bad variable names which should always be refused, separated by a comma.
-bad-names = ["foo", "bar", "baz", "toto", "tutu", "tata"]
-
-# Bad variable names regexes, separated by a comma. If names match any regex,
-# they will always be refused
-bad-names-rgxs = []
-
-# Naming style matching correct class attribute names.
-class-attribute-naming-style = "any"
-
-# Regular expression matching correct class attribute names. Overrides class-
-# attribute-naming-style.
-#class-attribute-rgx=
-
-# Naming style matching correct class names.
-class-naming-style = "PascalCase"
-
-# Regular expression matching correct class names. Overrides class-naming-
-# style.
-#class-rgx=
-
-# Naming style matching correct constant names.
-const-naming-style = "UPPER_CASE"
-
-# Regular expression matching correct constant names. Overrides const-naming-
-# style.
-#const-rgx=
-
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length = -1
-
-# Naming style matching correct function names.
-function-naming-style = "snake_case"
-
-# Regular expression matching correct function names. Overrides function-
-# naming-style.
-#function-rgx=
-
-# Good variable names which should always be accepted, separated by a comma.
-#good-names= ["i","j","k","ex","Run","_"]
-
-# Good variable names regexes, separated by a comma. If names match any regex,
-# they will always be accepted
-good-names-rgxs = []
-
-# Include a hint for the correct naming format with invalid-name.
-include-naming-hint = true
-
-# Naming style matching correct inline iteration names.
-inlinevar-naming-style = "any"
-
-# Regular expression matching correct inline iteration names. Overrides
-# inlinevar-naming-style.
-#inlinevar-rgx=
-
-# Naming style matching correct method names.
-method-naming-style = "snake_case"
-
-# Regular expression matching correct method names. Overrides method-naming-
-# style.
-#method-rgx=
-
-# Naming style matching correct module names.
-module-naming-style = "snake_case"
-
-# Regular expression matching correct module names. Overrides module-naming-
-# style.
-#module-rgx=
-
-# Colon-delimited sets of names that determine each other's naming style when
-# the name regexes allow several styles.
-name-group = []
-
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx = "^_"
-
-# List of decorators that produce properties, such as abc.abstractproperty. Add
-# to this list to register other decorators that produce valid properties.
-# These decorators are taken in consideration only for invalid-name.
-property-classes = "abc.abstractproperty"
-
-# Naming style matching correct variable names.
-variable-naming-style = "snake_case"
-
-# Regular expression matching correct variable names. Overrides variable-
-# naming-style.
-# variable-rgx=
-
-[tool.pylint.'IMPORTS']
-# List of modules that can be imported at any level, not just the top level
-# one.
-allow-any-import-level = []
-
-# Allow wildcard imports from modules that define __all__.
-allow-wildcard-with-all = false
-
-# Analyse import fallback blocks. This can be used to support both Python 2 and
-# 3 compatible code, which means that the block might have code that exists
-# only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks = false
-
-# Deprecated modules which should not be used, separated by a comma.
-deprecated-modules = "optparse,tkinter.tix"
-
-# Create a graph of external dependencies in the given file (report RP0402 must
-# not be disabled).
-ext-import-graph = []
-
-# Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled).
-import-graph = []
-
-# Create a graph of internal dependencies in the given file (report RP0402 must
-# not be disabled).
-int-import-graph = []
-
-# Force import order to recognize a module as part of the standard
-# compatibility libraries.
-known-standard-library = []
-
-# Force import order to recognize a module as part of a third party library.
-known-third-party = "enchant"
-
-# Couples of modules and preferred modules, separated by a comma.
-preferred-modules = []
-
-[tool.pylint.'CLASSES']
-# List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods = ["__init__", "__new__", "setUp", "__post_init__"]
-
-# List of member names, which should be excluded from the protected access
-# warning.
-exclude-protected = ["_asdict", "_fields", "_replace", "_source", "_make"]
-
-# List of valid names for the first argument in a class method.
-valid-classmethod-first-arg = "cls"
-
-# List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg = "cls"
-
-[tool.pylint.'DESIGN']
-# Maximum number of arguments for function / method.
-max-args = 5
-
-# Maximum number of attributes for a class (see R0902).
-max-attributes = 7
-
-# Maximum number of boolean expressions in an if statement (see R0916).
-max-bool-expr = 5
-
-# Maximum number of branch for function / method body.
-max-branches = 12
-
-# Maximum number of locals for function / method body.
-max-locals = 20
-
-# Maximum number of parents for a class (see R0901).
-max-parents = 7
-
-# Maximum number of public methods for a class (see R0904).
-max-public-methods = 25
-
-# Maximum number of return / yield for function / method body.
-max-returns = 6
-
-# Maximum number of statements in function / method body.
-max-statements = 50
-
-# Minimum number of public methods for a class (see R0903).
-min-public-methods = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ target-version = ["py38", "py39", "py310", "py311", "py312"]
 #  TEST RUNNER – Pytest
 # ──────────────────────────────
 [tool.pytest.ini_options]
-ignore = [".tox", ".direnv", "python_venv", "env", "venv"]
 
 # Sets list of directories that should be searched for tests when no specific
 # directories, files or test ids are given in the command line when executing

--- a/tests/components/test_expression_manager.py
+++ b/tests/components/test_expression_manager.py
@@ -11,7 +11,7 @@ from up_esb.components.expression_manager import ExpressionManager
 # Example fluents
 
 
-class TestObject:
+class ObjectUnderTest:
     def __init__(self, value: int):
         """Test object."""
         self.value = value
@@ -56,7 +56,7 @@ def fluent_arg_int_1_fun(arg: int):
     return arg
 
 
-def fluent_arg_object(arg: TestObject) -> TestObject:
+def fluent_arg_object(arg: ObjectUnderTest) -> ObjectUnderTest:
     """Fluent real 1."""
     return arg
 
@@ -74,7 +74,7 @@ class TestExpressionManager(unittest.TestCase):
         self._fluent_arg_bool_1 = self.bridge.create_fluent_from_function(fluent_arg_bool_1_fun)
         self._fluent_arg_int_1 = self.bridge.create_fluent_from_function(fluent_arg_int_1_fun)
 
-        self.bridge.create_types([TestObject])
+        self.bridge.create_types([ObjectUnderTest])
         self._fluent_arg_object = self.bridge.create_fluent_from_function(fluent_arg_object)
 
         self.ast = ExpressionManager()
@@ -140,14 +140,14 @@ class TestExpressionManager(unittest.TestCase):
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, False)
 
-        obj = self.bridge.create_object("obj", TestObject(1))
+        obj = self.bridge.create_object("obj", ObjectUnderTest(1))
         result = self.ast.convert(
             Equals(self._fluent_arg_object(obj), self._fluent_arg_object(obj))
         )
         actual = eval(compile(result, filename="<ast>", mode="eval"))
         self.assertEqual(actual, True)
 
-        obj1 = self.bridge.create_object("obj1", TestObject(2))
+        obj1 = self.bridge.create_object("obj1", ObjectUnderTest(2))
         result = self.ast.convert(
             Equals(self._fluent_arg_object(obj), self._fluent_arg_object(obj1))
         )

--- a/up_esb/__init__.py
+++ b/up_esb/__init__.py
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 """Embedded Systems Bridge."""
-from up_esb.bridge import Bridge
-from up_esb.components import *
+from up_esb.bridge import Bridge as Bridge
+
+__all__ = ["Bridge"]

--- a/up_esb/bridge.py
+++ b/up_esb/bridge.py
@@ -139,7 +139,7 @@ class Bridge:
                 # Note: Use "context" to resolve potential relay to Python source file.
                 api_type = (
                     api_type.__dict__["context"][name]
-                    if "context" in api_type.__dict__.keys()
+                    if "context" in api_type.__dict__
                     else api_type.__dict__[name]
                 )
             assert isinstance(api_type, type), f"{api_type} is not a type!"
@@ -174,7 +174,7 @@ class Bridge:
                 if result_api_type
                 else (
                     self.get_type(signature["return"])
-                    if signature and "return" in signature.keys()
+                    if signature and "return" in signature
                     else BoolType()
                 )
             ),
@@ -320,8 +320,8 @@ class Bridge:
 
     def get_object(self, api_object: object) -> Object:
         """Return UP object corresponding to api_object if it exists, else api_object itself."""
-        name = getattr(api_object, "name") if hasattr(api_object, "name") else str(api_object)
-        return self._objects[name] if name in self._objects else api_object
+        name = api_object.name if hasattr(api_object, "name") else str(api_object)
+        return self._objects.get(name, api_object)
 
     def define_problem(
         self,
@@ -423,11 +423,7 @@ class Bridge:
             executable_preconditions: Dict[str, List[Callable]] = {}
             for interval, preconditions in executable_graph.nodes[node_id]["preconditions"].items():
                 # Interval is start for instantaneous actions, and (start, end) for timed actions.
-                executable_preconditions[interval] = (
-                    []
-                    if interval not in executable_preconditions
-                    else executable_preconditions[interval]
-                )
+                executable_preconditions[interval] = executable_preconditions.get(interval, [])
 
                 for precondition in preconditions:
                     executable_preconditions[interval].append(
@@ -438,9 +434,7 @@ class Bridge:
             # Action Effects
             executable_effects: Dict[str, List[Tuple[Callable, typing.Any]]] = {}
             for interval, effects in executable_graph.nodes[node_id]["postconditions"].items():
-                executable_effects[interval] = (
-                    [] if interval not in executable_effects else executable_effects[interval]
-                )
+                executable_effects[interval] = executable_effects.get(interval, [])
 
                 for effect in effects:
                     executable_effects[interval].append(

--- a/up_esb/components/graph.py
+++ b/up_esb/components/graph.py
@@ -30,7 +30,7 @@ from unified_planning.shortcuts import DurativeAction, Fraction, InstantaneousAc
 
 
 def plan_to_dependency_graph(
-    plan: Union[SequentialPlan, TimeTriggeredPlan, PartialOrderPlan]
+    plan: Union[SequentialPlan, TimeTriggeredPlan, PartialOrderPlan],
 ) -> nx.DiGraph:
     """Convert UP Plan to Dependency Graph."""
     if isinstance(plan, SequentialPlan):
@@ -150,13 +150,10 @@ def _time_triggered_plan_to_dependency_graph(plan: TimeTriggeredPlan) -> nx.DiGr
         preconditions={},
         postconditions={},
     )
-    for i, (start, action, duration) in enumerate(plan.timed_actions):
+    for i, (_, action, duration) in enumerate(plan.timed_actions):
         child_id = i + 1
         # TODO: Handle None Durations as Instantaneous Action Node
-        if duration:
-            duration = float(duration.numerator) / float(duration.denominator)
-        else:
-            duration = 0.0
+        duration = float(duration.numerator) / float(duration.denominator) if duration else 0.0
         parameters, preconditions, postconditions = _process_action(action)
 
         # TODO: Check this logic with respect to UP

--- a/up_esb/plexmo/dispatcher.py
+++ b/up_esb/plexmo/dispatcher.py
@@ -81,7 +81,7 @@ class PlanDispatcher:
         while self._status != DispatcherStatus.REPLANNING or not self._node_data:
             # Get the next node to be executed
             node_id, node = self._node_data.pop(0) if len(self._node_data) > 0 else (None, None)
-            if node_id is None:
+            if node is None:
                 break
             if self._status == DispatcherStatus.REPLANNING:
                 self._setup_monitor(self._graph)
@@ -155,21 +155,14 @@ class PlanDispatcher:
 
     def _check_node_status(self, nodes: list, status: ActionNodeStatus):
         """Check node status from monitoring graph."""
-        for node_id in nodes:
-            if self.monitor_graph.nodes[node_id]["status"] != status:
-                return False
-
-        return True
+        return all(self.monitor_graph.nodes[node_id]["status"] == status for node_id in nodes)
 
     def _check_result(self, result: ActionResult):
-        if (
+        return not (
             result.precondition_status != ConditionStatus.SUCCEEDED
             or result.action_status != ActionNodeStatus.SUCCEEDED
             or result.postcondition_status != ConditionStatus.SUCCEEDED
-        ):
-            return False
-
-        return True
+        )
 
     def _setup_monitor(self, graph: nx.DiGraph):
         """Setup monitor for monitoring the execution."""
@@ -194,7 +187,7 @@ class PlanDispatcher:
     def set_replan_callback(self, callback, **args):
         """Set callback function that triggers replanning"""
 
-        if args.get("rules", None) is not None:
+        if args.get("rules") is not None:
             if not isinstance(self._rules, dict):
                 raise UPESBException(
                     "Rules argument should be a dictionary with rule name as key and rule as value"
@@ -203,7 +196,7 @@ class PlanDispatcher:
         else:
             self._rules = {}
 
-        if args.get("plan", None) is not None:
+        if args.get("plan") is not None:
             self._plan = args.get("plan")
         else:
             raise UPESBException("Plan argument is not provided for replanning callback")


### PR DESCRIPTION
This PR updates the pre-commit-config to replace pylint and isort with ruff.
It also fixes the CI workflow config by using ubuntu-latest as 20.04 is deprecated and not avaialbel anymore for github actions.

The reason for using ruff where version incompatibilities between Python 3.12 and the previously used version of pylint. It was also not possible to update pylint to a newer version as this would break compatibility with Python 3.8 which we still have, also this debatable as 3.8 is also not supported, anymore.

Additionally, using ruff has the advantage of being faster than pylint, which is the reasong that pylint documentation does not recommend to use it in the pre-commit stage.